### PR TITLE
Plat 8086

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/Queryable.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/Queryable.java
@@ -20,6 +20,10 @@ public interface Queryable<T> {
 
     List<T> query(String filter, String sortBy, boolean ascending);
 
+    List<T> query(String filter, Integer pageSize);
+
+    List<T> query(String filter, String sortBy, boolean ascending, Integer pageSize);
+
     int delete(String filter);
 
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimGroupMembershipManager.java
@@ -44,6 +44,7 @@ public interface ScimGroupMembershipManager extends Queryable<ScimGroupMember> {
      * @throws ScimResourceNotFoundException
      */
     List<ScimGroupMember> getMembers(String groupId, String filter, boolean includeEntities) throws ScimResourceNotFoundException;
+    List<ScimGroupMember> getMembers(String groupId, String filter, boolean includeEntities, Integer pageSizeOverride) throws ScimResourceNotFoundException;
 
     /**
      * Retrieve members that have the specified authority on the group

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 public class ScimGroupBootstrap implements InitializingBean {
 
-    @Value("${brian.pageSizeOverride:200}")
+    @Value("${bootstrap.pageSizeOverride:200}")
     private Integer pageSizeOverride;
 
     private Map<String, String> groups;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
@@ -26,6 +26,7 @@ import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceAlreadyExistsExc
 import org.cloudfoundry.identity.uaa.util.MapCollector;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.util.StringUtils;
@@ -40,6 +41,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ScimGroupBootstrap implements InitializingBean {
+
+    @Value("${brian.pageSizeOverride:200}")
+    private Integer pageSizeOverride;
 
     private Map<String, String> groups;
 
@@ -255,7 +259,7 @@ public class ScimGroupBootstrap implements InitializingBean {
         List<ScimGroup> g = scimGroupProvisioning.query(String.format(GROUP_BY_NAME_FILTER, name));
         if (g != null && !g.isEmpty()) {
             ScimGroup gr = g.get(0);
-            gr.setMembers(membershipManager.getMembers(gr.getId(), null, false));
+            gr.setMembers(membershipManager.getMembers(gr.getId(), null, false, pageSizeOverride));
             return gr;
         }
         logger.debug("could not find group with name");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
@@ -210,7 +210,11 @@ public class JdbcScimGroupMembershipManager extends AbstractQueryable<ScimGroupM
     }
 
     @Override
-    public List<ScimGroupMember> getMembers(final String groupId, String filter, boolean includeEntities) throws ScimResourceNotFoundException {
+    public List<ScimGroupMember> getMembers(String groupId, String filter, boolean includeEntities) throws ScimResourceNotFoundException {
+        return getMembers(groupId, filter, includeEntities, null);
+    }
+    @Override
+    public List<ScimGroupMember> getMembers(final String groupId, String filter, boolean includeEntities, Integer pageSizeOverride) throws ScimResourceNotFoundException {
         String scopedFilter;
         if (StringUtils.hasText(filter)) {
             // validate filter syntax
@@ -220,7 +224,7 @@ public class JdbcScimGroupMembershipManager extends AbstractQueryable<ScimGroupM
         else {
             scopedFilter = String.format("group_id eq \"%s\"", groupId);
         }
-        List<ScimGroupMember> result = query(scopedFilter, "member_id", true);
+        List<ScimGroupMember> result = query(scopedFilter, "member_id", true, pageSizeOverride);
 
         if(includeEntities) {
             for(ScimGroupMember member : result) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/remote/RemoteScimUserProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/remote/RemoteScimUserProvisioning.java
@@ -75,7 +75,19 @@ public class RemoteScimUserProvisioning implements ScimUserProvisioning {
 
     @Override
     @SuppressWarnings("unchecked")
+    public List<ScimUser> query(String filter, Integer pageSizeOverride) {
+        return query(filter);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public List<ScimUser> query(String filter, String sortBy, boolean ascending) {
+        return query(filter, sortBy, ascending, null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<ScimUser> query(String filter, String sortBy, boolean ascending, Integer pageSizeOverride) {
         String order = ascending ? "" : "&sortOrder=descending";
         return restTemplate.getForObject(baseUrl + "/Users?filter={filter}&sortBy={sortBy}" + order, List.class,
                         filter, sortBy);


### PR DESCRIPTION
- i wasn't quite sure how to go about PR'ing this into our fork. This PR is set to merge into `3.2.1_fp2`, which is a branch I just created that is identical to our latest forked branch `3.2.1_fp1`.

- add ability to override the pageSize for the bootstrapping class with a property value
- after going knee deep in old, nauseating, non springboot uaa code i realized it wasn't actually the query itself that was the problem, it was the tiny non customizable default page size of 200. setting it to a much higher value dramatically increased the startup time. I tested setting the page size to `50000` and it started in 40 seconds. the snapshot db only went up by 1 % 
- i tried to touch as little as possible, and only implemented the custom page size where we saw the problem, in the groups bootstrapping class.
- will have to add the property bootstrap.pageSizeOverride to our uaa.yml for this to work, otherwise it will use the default 200. once we get this in qa ill play around with the value to make sure there aren't any unwanted side effects. if the db cpu is still concerning then I'll try to improve the query as well

